### PR TITLE
feat(proxy): add credential injection for proxy requests

### DIFF
--- a/cmd/devsandbox/filter.go
+++ b/cmd/devsandbox/filter.go
@@ -254,11 +254,7 @@ func processLogFile(path string, domainMap map[string]*DomainStats) error {
 			continue
 		}
 
-		domain := parsedURL.Host
-		// Remove port
-		if idx := strings.LastIndex(domain, ":"); idx > 0 {
-			domain = domain[:idx]
-		}
+		domain := proxy.NormalizeHost(parsedURL.Host)
 
 		// Update stats
 		stats, ok := domainMap[domain]

--- a/cmd/devsandbox/main.go
+++ b/cmd/devsandbox/main.go
@@ -170,6 +170,7 @@ func runSandbox(cmd *cobra.Command, args []string) error {
 		proxyCfg := proxy.NewConfig(cfg.SandboxRoot, proxyPort)
 		proxyCfg.LogReceivers = appCfg.Logging.Receivers
 		proxyCfg.LogAttributes = appCfg.Logging.Attributes
+		proxyCfg.CredentialInjectors = proxy.BuildCredentialInjectors(appCfg.Proxy.Credentials)
 
 		// Build filter configuration
 		proxyCfg.Filter = buildFilterConfig(appCfg, cmd, filterDefault, allowDomains, blockDomains)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,12 @@ type ProxyConfig struct {
 
 	// Filter contains HTTP request filtering configuration.
 	Filter ProxyFilterConfig `toml:"filter"`
+
+	// Credentials contains per-injector credential injection configuration.
+	// Each key is an injector name (e.g., "github"), and the value is
+	// a map of injector-specific settings. Each injector parses its own config.
+	// All injectors are disabled by default.
+	Credentials map[string]any `toml:"credentials"`
 }
 
 // IsEnabled returns whether proxy is enabled (defaults to false).
@@ -563,6 +569,15 @@ port = 8080
 # pattern = "*.tracking.io"
 # action = "block"
 # reason = "Tracking domain blocked"
+
+# Credential injection (requires proxy mode)
+# Injects authentication tokens into outbound requests for specific domains.
+# Tokens are read from host environment and never exposed to the sandbox.
+# All injectors are disabled by default.
+
+# GitHub API token injection (reads GITHUB_TOKEN or GH_TOKEN from host)
+# [proxy.credentials.github]
+# enabled = true
 
 # Sandbox settings
 [sandbox]

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -55,6 +55,9 @@ func mergeConfigs(base, overlay *Config) *Config {
 		result.Overlay.Enabled = overlay.Overlay.Enabled
 	}
 
+	// Proxy credentials: deep merge (same pattern as tools)
+	result.Proxy.Credentials = mergeToolsConfig(base.Proxy.Credentials, overlay.Proxy.Credentials)
+
 	// Tools: deep merge
 	result.Tools = mergeToolsConfig(base.Tools, overlay.Tools)
 

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -35,6 +35,11 @@ type Config struct {
 
 	// Filter contains HTTP request filtering configuration.
 	Filter *FilterConfig
+
+	// CredentialInjectors add authentication to requests for specific domains.
+	// Built by BuildCredentialInjectors() from [proxy.credentials] config.
+	// If nil/empty, no credential injection is performed.
+	CredentialInjectors []CredentialInjector
 }
 
 func NewConfig(sandboxBase string, port int) *Config {

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+)
+
+// CredentialInjector adds authentication to requests for specific domains.
+// This allows the proxy to authenticate requests without exposing credentials
+// to the sandbox environment.
+type CredentialInjector interface {
+	// Match returns true if this injector handles the request.
+	Match(req *http.Request) bool
+	// Inject adds credentials to the request (modifies in place).
+	Inject(req *http.Request)
+}
+
+// ConfigurableInjector extends CredentialInjector with self-registration
+// and configuration support. Each injector knows how to parse its own config
+// from a map[string]any (the raw TOML section).
+type ConfigurableInjector interface {
+	CredentialInjector
+	// Name returns the injector's registry name (e.g., "github").
+	Name() string
+	// Configure applies injector-specific configuration.
+	// cfg is the raw TOML map from [proxy.credentials.<name>].
+	Configure(cfg map[string]any)
+	// Enabled returns whether this injector is active after configuration.
+	Enabled() bool
+}
+
+// credentialRegistry maps injector names to factory functions.
+var credentialRegistry = make(map[string]func() ConfigurableInjector)
+
+// RegisterCredentialInjector registers a credential injector factory.
+// Injectors should call this in their init() function.
+func RegisterCredentialInjector(name string, factory func() ConfigurableInjector) {
+	credentialRegistry[name] = factory
+}
+
+// BuildCredentialInjectors creates injectors from config.
+// Only injectors that are explicitly enabled and have valid credentials are returned.
+// Unknown injector names are logged to stderr and skipped.
+func BuildCredentialInjectors(credentials map[string]any) []CredentialInjector {
+	var injectors []CredentialInjector
+
+	// Sort keys for deterministic ordering
+	names := make([]string, 0, len(credentials))
+	for name := range credentials {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		rawCfg := credentials[name]
+		factory, ok := credentialRegistry[name]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Warning: unknown credential injector %q, skipping\n", name)
+			continue
+		}
+
+		cfg, _ := rawCfg.(map[string]any)
+		injector := factory()
+		injector.Configure(cfg)
+
+		if injector.Enabled() {
+			injectors = append(injectors, injector)
+		}
+	}
+
+	return injectors
+}
+
+// RegisteredCredentialInjectors returns the names of all registered injectors.
+func RegisteredCredentialInjectors() []string {
+	names := make([]string, 0, len(credentialRegistry))
+	for name := range credentialRegistry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/proxy/credentials_test.go
+++ b/internal/proxy/credentials_test.go
@@ -1,0 +1,245 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGitHubCredentialInjector_Match(t *testing.T) {
+	injector := &GitHubCredentialInjector{token: "test-token", enabled: true}
+
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"matches api.github.com", "https://api.github.com/repos/foo/bar", true},
+		{"matches api.github.com with path", "https://api.github.com/rate_limit", true},
+		{"no match github.com", "https://github.com/foo/bar", false},
+		{"no match raw.githubusercontent.com", "https://raw.githubusercontent.com/foo/bar/main/file", false},
+		{"no match other domain", "https://example.com/api", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			if got := injector.Match(req); got != tt.expected {
+				t.Errorf("Match() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGitHubCredentialInjector_Match_WithPort(t *testing.T) {
+	injector := &GitHubCredentialInjector{token: "test-token", enabled: true}
+
+	tests := []struct {
+		name     string
+		host     string
+		expected bool
+	}{
+		{"api.github.com no port", "api.github.com", true},
+		{"api.github.com with 443", "api.github.com:443", true},
+		{"api.github.com with 8080", "api.github.com:8080", true},
+		{"github.com no port", "github.com", false},
+		{"github.com with 443", "github.com:443", false},
+		{"other host", "example.com", false},
+		{"other host with port", "example.com:443", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "https://placeholder/path", nil)
+			req.URL.Host = tt.host
+			if got := injector.Match(req); got != tt.expected {
+				t.Errorf("Match() = %v, want %v for host %q", got, tt.expected, tt.host)
+			}
+		})
+	}
+}
+
+func TestGitHubCredentialInjector_Inject(t *testing.T) {
+	t.Run("injects token when not present", func(t *testing.T) {
+		injector := &GitHubCredentialInjector{token: "my-secret-token", enabled: true}
+		req, _ := http.NewRequest("GET", "https://api.github.com/repos/foo/bar", nil)
+
+		injector.Inject(req)
+
+		auth := req.Header.Get("Authorization")
+		if auth != "Bearer my-secret-token" {
+			t.Errorf("Authorization = %q, want %q", auth, "Bearer my-secret-token")
+		}
+	})
+
+	t.Run("does not override existing auth", func(t *testing.T) {
+		injector := &GitHubCredentialInjector{token: "my-secret-token", enabled: true}
+		req, _ := http.NewRequest("GET", "https://api.github.com/repos/foo/bar", nil)
+		req.Header.Set("Authorization", "Bearer existing-token")
+
+		injector.Inject(req)
+
+		auth := req.Header.Get("Authorization")
+		if auth != "Bearer existing-token" {
+			t.Errorf("Authorization = %q, want %q (should not override)", auth, "Bearer existing-token")
+		}
+	})
+
+	t.Run("no-op when token is empty", func(t *testing.T) {
+		injector := &GitHubCredentialInjector{token: "", enabled: true}
+		req, _ := http.NewRequest("GET", "https://api.github.com/repos/foo/bar", nil)
+
+		injector.Inject(req)
+
+		auth := req.Header.Get("Authorization")
+		if auth != "" {
+			t.Errorf("Authorization = %q, want empty", auth)
+		}
+	})
+}
+
+func TestGitHubCredentialInjector_Configure(t *testing.T) {
+	t.Run("enabled with GITHUB_TOKEN", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "token-from-github-token")
+		t.Setenv("GH_TOKEN", "token-from-gh-token")
+
+		injector := &GitHubCredentialInjector{}
+		injector.Configure(map[string]any{"enabled": true})
+
+		if !injector.Enabled() {
+			t.Error("expected enabled")
+		}
+		if injector.token != "token-from-github-token" {
+			t.Errorf("token = %q, want %q", injector.token, "token-from-github-token")
+		}
+	})
+
+	t.Run("falls back to GH_TOKEN", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GH_TOKEN", "token-from-gh-token")
+
+		injector := &GitHubCredentialInjector{}
+		injector.Configure(map[string]any{"enabled": true})
+
+		if !injector.Enabled() {
+			t.Error("expected enabled")
+		}
+		if injector.token != "token-from-gh-token" {
+			t.Errorf("token = %q, want %q", injector.token, "token-from-gh-token")
+		}
+	})
+
+	t.Run("disabled when enabled=false", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "some-token")
+
+		injector := &GitHubCredentialInjector{}
+		injector.Configure(map[string]any{"enabled": false})
+
+		if injector.Enabled() {
+			t.Error("expected disabled")
+		}
+	})
+
+	t.Run("disabled when no token available", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GH_TOKEN", "")
+
+		injector := &GitHubCredentialInjector{}
+		injector.Configure(map[string]any{"enabled": true})
+
+		if injector.Enabled() {
+			t.Error("expected disabled when no token")
+		}
+	})
+
+	t.Run("disabled with nil config", func(t *testing.T) {
+		injector := &GitHubCredentialInjector{}
+		injector.Configure(nil)
+
+		if injector.Enabled() {
+			t.Error("expected disabled with nil config")
+		}
+	})
+
+	t.Run("disabled when enabled not set", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "some-token")
+
+		injector := &GitHubCredentialInjector{}
+		injector.Configure(map[string]any{})
+
+		if injector.Enabled() {
+			t.Error("expected disabled when enabled not set")
+		}
+	})
+}
+
+func TestBuildCredentialInjectors(t *testing.T) {
+	t.Run("returns github injector when enabled with token", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "test-token")
+
+		injectors := BuildCredentialInjectors(map[string]any{
+			"github": map[string]any{"enabled": true},
+		})
+
+		if len(injectors) != 1 {
+			t.Fatalf("len(injectors) = %d, want 1", len(injectors))
+		}
+	})
+
+	t.Run("empty when no credentials configured", func(t *testing.T) {
+		injectors := BuildCredentialInjectors(nil)
+
+		if len(injectors) != 0 {
+			t.Errorf("len(injectors) = %d, want 0", len(injectors))
+		}
+	})
+
+	t.Run("empty when github disabled", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "test-token")
+
+		injectors := BuildCredentialInjectors(map[string]any{
+			"github": map[string]any{"enabled": false},
+		})
+
+		if len(injectors) != 0 {
+			t.Errorf("len(injectors) = %d, want 0", len(injectors))
+		}
+	})
+
+	t.Run("skips unknown injectors", func(t *testing.T) {
+		injectors := BuildCredentialInjectors(map[string]any{
+			"nonexistent": map[string]any{"enabled": true},
+		})
+
+		if len(injectors) != 0 {
+			t.Errorf("len(injectors) = %d, want 0", len(injectors))
+		}
+	})
+
+	t.Run("empty when no tokens available", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GH_TOKEN", "")
+
+		injectors := BuildCredentialInjectors(map[string]any{
+			"github": map[string]any{"enabled": true},
+		})
+
+		if len(injectors) != 0 {
+			t.Errorf("len(injectors) = %d, want 0 (no token available)", len(injectors))
+		}
+	})
+}
+
+func TestRegisteredCredentialInjectors(t *testing.T) {
+	names := RegisteredCredentialInjectors()
+
+	found := false
+	for _, name := range names {
+		if name == "github" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'github' in registered injectors, got %v", names)
+	}
+}

--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -155,7 +155,7 @@ func (e *FilterEngine) Match(req *http.Request) FilterDecision {
 func (e *FilterEngine) getMatchTarget(req *http.Request, scope FilterScope) string {
 	switch scope {
 	case FilterScopeHost:
-		return normalizeHost(req.Host)
+		return NormalizeHost(req.Host)
 
 	case FilterScopePath:
 		return req.URL.Path
@@ -164,12 +164,12 @@ func (e *FilterEngine) getMatchTarget(req *http.Request, scope FilterScope) stri
 		return req.URL.String()
 
 	default:
-		return normalizeHost(req.Host)
+		return NormalizeHost(req.Host)
 	}
 }
 
-// normalizeHost extracts the hostname without port, handling IPv6 addresses correctly.
-func normalizeHost(hostport string) string {
+// NormalizeHost extracts the hostname without port, handling IPv6 addresses correctly.
+func NormalizeHost(hostport string) string {
 	// Use net.SplitHostPort for robust parsing
 	host, _, err := net.SplitHostPort(hostport)
 	if err != nil {
@@ -191,7 +191,7 @@ func (e *FilterEngine) CacheDecision(host string, action FilterAction) {
 
 	e.cacheMu.Lock()
 	defer e.cacheMu.Unlock()
-	e.decisionCache[normalizeHost(host)] = action
+	e.decisionCache[NormalizeHost(host)] = action
 }
 
 // getCachedDecision retrieves a cached decision for a host.
@@ -199,7 +199,7 @@ func (e *FilterEngine) CacheDecision(host string, action FilterAction) {
 func (e *FilterEngine) getCachedDecision(host string) FilterAction {
 	e.cacheMu.RLock()
 	defer e.cacheMu.RUnlock()
-	return e.decisionCache[normalizeHost(host)]
+	return e.decisionCache[NormalizeHost(host)]
 }
 
 // ClearCache clears all cached decisions.

--- a/internal/proxy/filter_test.go
+++ b/internal/proxy/filter_test.go
@@ -389,9 +389,9 @@ func TestNormalizeHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := normalizeHost(tt.input)
+			got := NormalizeHost(tt.input)
 			if got != tt.expected {
-				t.Errorf("normalizeHost(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("NormalizeHost(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}

--- a/internal/proxy/github.go
+++ b/internal/proxy/github.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"os"
+)
+
+func init() {
+	RegisterCredentialInjector("github", func() ConfigurableInjector {
+		return &GitHubCredentialInjector{}
+	})
+}
+
+// GitHubCredentialInjector injects GitHub API tokens for api.github.com requests.
+// It reads the token from GITHUB_TOKEN or GH_TOKEN environment variables.
+type GitHubCredentialInjector struct {
+	token   string
+	enabled bool
+}
+
+// Name returns "github".
+func (g *GitHubCredentialInjector) Name() string {
+	return "github"
+}
+
+// Configure reads the injector config from the raw TOML map.
+// Expects: enabled = true/false (required, defaults to false).
+func (g *GitHubCredentialInjector) Configure(cfg map[string]any) {
+	g.enabled = false
+
+	if cfg == nil {
+		return
+	}
+
+	if enabled, ok := cfg["enabled"].(bool); ok && enabled {
+		g.token = os.Getenv("GITHUB_TOKEN")
+		if g.token == "" {
+			g.token = os.Getenv("GH_TOKEN")
+		}
+		g.enabled = g.token != ""
+	}
+}
+
+// Enabled returns true if the injector is configured and has a valid token.
+func (g *GitHubCredentialInjector) Enabled() bool {
+	return g.enabled
+}
+
+// Match returns true for requests to api.github.com.
+func (g *GitHubCredentialInjector) Match(req *http.Request) bool {
+	// Host may include port (e.g., "api.github.com:443")
+	host := req.URL.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return host == "api.github.com"
+}
+
+// Inject adds the Authorization header if not already present.
+func (g *GitHubCredentialInjector) Inject(req *http.Request) {
+	// Don't override existing authorization
+	if req.Header.Get("Authorization") != "" {
+		return
+	}
+	if g.token != "" {
+		req.Header.Set("Authorization", "Bearer "+g.token)
+	}
+}

--- a/internal/proxy/github.go
+++ b/internal/proxy/github.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"net"
 	"net/http"
 	"os"
 )
@@ -49,12 +48,7 @@ func (g *GitHubCredentialInjector) Enabled() bool {
 
 // Match returns true for requests to api.github.com.
 func (g *GitHubCredentialInjector) Match(req *http.Request) bool {
-	// Host may include port (e.g., "api.github.com:443")
-	host := req.URL.Host
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	}
-	return host == "api.github.com"
+	return NormalizeHost(req.URL.Host) == "api.github.com"
 }
 
 // Inject adds the Authorization header if not already present.


### PR DESCRIPTION
Add extensible credential injection system that injects authentication tokens into outbound proxy requests without exposing credentials to the sandbox environment.

- Registry-based injector architecture with self-registration
- GitHub API injector: reads GITHUB_TOKEN/GH_TOKEN from host env
- Tokens injected at proxy level, never exposed to sandbox
- Only injects for matching domains, won't override existing headers
- Request logging captures requests before injection (tokens not logged)
- Config via [proxy.credentials.<name>] sections with deep merge support