### PR TITLE
feat(cli): add --git-mode flag to override git access per session

### DIFF
--- a/internal/sandbox/tools/git.go
+++ b/internal/sandbox/tools/git.go
@@ -31,6 +31,16 @@ const (
 	GitModeDisabled GitMode = "disabled"
 )
 
+// ValidGitMode returns true if the given string is a valid git mode value.
+func ValidGitMode(mode string) bool {
+	switch strings.ToLower(mode) {
+	case "readonly", "readwrite", "disabled":
+		return true
+	default:
+		return false
+	}
+}
+
 // Git provides configurable git configuration.
 // Supports three modes: readonly (default), readwrite, and disabled.
 type Git struct {


### PR DESCRIPTION
Allow temporarily changing git tool mode (readonly, readwrite, disabled) via CLI flag without modifying the config file.