### PR TITLE
feat: allow proxy monitor to start before sandbox

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  push: { }
+  push:
+    branches: [main]
   pull_request: { }
   schedule:
     - cron: '0 2 * * *'
@@ -117,7 +118,7 @@ jobs:
     name: Docker Publish
     runs-on: ubuntu-latest
     needs: [lint]
-    if: github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/docker' || startsWith(github.ref, 'refs/tags/v')))
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     permissions:
       contents: read
       packages: write

--- a/.mise.ci.toml
+++ b/.mise.ci.toml
@@ -2,7 +2,7 @@
 # Used by GitHub Actions to set up tools for e2e tests
 
 [tools]
-go = "1.26.6"
+go = "1.26.0"
 task = "3.40"
 golangci-lint = "2.9.0"
 neovim = "0.10"

--- a/cmd/devsandbox/proxy.go
+++ b/cmd/devsandbox/proxy.go
@@ -65,8 +65,8 @@ Requests that don't receive a response within 30 seconds are automatically rejec
 	}
 }
 
-// detectAskSocket finds the ask socket for the current directory's sandbox.
-func detectAskSocket() (string, error) {
+// resolveSandboxBase returns the sandbox base path for the current directory's project.
+func resolveSandboxBase() (string, error) {
 	appCfg, _, projectDir, err := config.LoadConfig()
 	if err != nil {
 		return "", err
@@ -82,9 +82,17 @@ func detectAskSocket() (string, error) {
 	}
 
 	projectName := sandbox.GenerateSandboxName(projectDir)
-	socketPath := filepath.Join(basePath, projectName, "logs", "proxy", ".ask", "ask.sock")
+	return filepath.Join(basePath, projectName), nil
+}
 
-	// Check if socket exists
+// detectAskSocket finds the ask socket for the current directory's sandbox.
+func detectAskSocket() (string, error) {
+	sandboxBase, err := resolveSandboxBase()
+	if err != nil {
+		return "", err
+	}
+
+	socketPath := proxy.AskSocketPath(sandboxBase)
 	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
 		return "", fmt.Errorf("no ask socket found at %s\nMake sure the sandbox is running with --filter-default=ask", socketPath)
 	}

--- a/internal/proxy/askmode.go
+++ b/internal/proxy/askmode.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -63,13 +62,12 @@ type AskServer struct {
 
 // NewAskServer creates a new ask mode server.
 func NewAskServer(sandboxRoot string) (*AskServer, error) {
-	// Create socket in sandbox root directory
-	socketDir := filepath.Join(sandboxRoot, ".ask")
+	socketDir := AskSocketDir(sandboxRoot)
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create socket directory: %w", err)
 	}
 
-	socketPath := filepath.Join(socketDir, "ask.sock")
+	socketPath := AskSocketPath(sandboxRoot)
 
 	// Remove stale socket
 	_ = os.Remove(socketPath)

--- a/internal/proxy/askmode.go
+++ b/internal/proxy/askmode.go
@@ -220,7 +220,11 @@ func (s *AskServer) handleClientResponses() {
 			if closed {
 				return
 			}
-			// Monitor disconnected — cancel all pending requests
+			// Monitor disconnected — mark connection dead and cancel all pending requests
+			s.mu.Lock()
+			s.conn = nil
+			s.mu.Unlock()
+
 			s.pendingMu.Lock()
 			for id, ch := range s.pending {
 				close(ch)

--- a/internal/proxy/askmode_integration_test.go
+++ b/internal/proxy/askmode_integration_test.go
@@ -61,8 +61,14 @@ func TestIntegration_MonitorFirst(t *testing.T) {
 		t.Fatalf("expected client mode, got %s", server.Mode())
 	}
 
-	// Give client time to connect
-	time.Sleep(100 * time.Millisecond)
+	// Wait for client to connect
+	deadline := time.Now().Add(5 * time.Second)
+	for !server.HasMonitor() {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for monitor connection")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// Step 3: Send a request — should be approved by monitor
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -95,7 +101,14 @@ func TestIntegration_MonitorFirst(t *testing.T) {
 		t.Fatalf("expected client mode after restart, got %s", server2.Mode())
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for client to reconnect
+	deadline2 := time.Now().Add(5 * time.Second)
+	for !server2.HasMonitor() {
+		if time.Now().After(deadline2) {
+			t.Fatal("timeout waiting for monitor reconnection")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel2()

--- a/internal/proxy/askmode_integration_test.go
+++ b/internal/proxy/askmode_integration_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIntegration_MonitorFirst(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 	socketDir := AskSocketDir(dir)
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
 		t.Fatalf("mkdir failed: %v", err)

--- a/internal/proxy/askmode_integration_test.go
+++ b/internal/proxy/askmode_integration_test.go
@@ -1,0 +1,116 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestIntegration_MonitorFirst(t *testing.T) {
+	dir := t.TempDir()
+	socketDir := AskSocketDir(dir)
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	socketPath := AskSocketPath(dir)
+
+	// Step 1: Start monitor (creates socket, listens)
+	monitorListener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("monitor listen failed: %v", err)
+	}
+	defer func() { _ = monitorListener.Close() }()
+
+	// Monitor auto-approves in background
+	go func() {
+		for {
+			conn, err := monitorListener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				dec := json.NewDecoder(c)
+				enc := json.NewEncoder(c)
+				for {
+					var req AskRequest
+					if err := dec.Decode(&req); err != nil {
+						return
+					}
+					_ = enc.Encode(AskResponse{
+						ID:     req.ID,
+						Action: FilterActionAllow,
+					})
+				}
+			}(conn)
+		}
+	}()
+
+	// Step 2: AskServer starts, detects socket, connects as client
+	server, err := NewAskServer(dir)
+	if err != nil {
+		t.Fatalf("NewAskServer failed: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if server.Mode() != AskModeClient {
+		t.Fatalf("expected client mode, got %s", server.Mode())
+	}
+
+	// Give client time to connect
+	time.Sleep(100 * time.Millisecond)
+
+	// Step 3: Send a request — should be approved by monitor
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := server.Ask(ctx, &AskRequest{
+		ID:     "integration-1",
+		Method: "GET",
+		URL:    "https://example.com/test",
+		Host:   "example.com",
+		Path:   "/test",
+	})
+	if err != nil {
+		t.Fatalf("Ask failed: %v", err)
+	}
+	if resp.Action != FilterActionAllow {
+		t.Errorf("expected allow, got %s", resp.Action)
+	}
+
+	// Step 4: Simulate sandbox restart — close AskServer, create new one
+	_ = server.Close()
+
+	server2, err := NewAskServer(dir)
+	if err != nil {
+		t.Fatalf("second NewAskServer failed: %v", err)
+	}
+	defer func() { _ = server2.Close() }()
+
+	if server2.Mode() != AskModeClient {
+		t.Fatalf("expected client mode after restart, got %s", server2.Mode())
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+
+	resp2, err := server2.Ask(ctx2, &AskRequest{
+		ID:     "integration-2",
+		Method: "POST",
+		URL:    "https://example.com/api",
+		Host:   "example.com",
+		Path:   "/api",
+	})
+	if err != nil {
+		t.Fatalf("second Ask failed: %v", err)
+	}
+	if resp2.Action != FilterActionAllow {
+		t.Errorf("expected allow, got %s", resp2.Action)
+	}
+}

--- a/internal/proxy/askmode_test.go
+++ b/internal/proxy/askmode_test.go
@@ -114,8 +114,14 @@ func TestAskServer_ClientMode_Ask(t *testing.T) {
 	}
 	defer func() { _ = server.Close() }()
 
-	// Give client time to connect
-	time.Sleep(100 * time.Millisecond)
+	// Wait for client to connect
+	deadline := time.Now().Add(2 * time.Second)
+	for !server.HasMonitor() {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for monitor connection")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/internal/proxy/askmode_test.go
+++ b/internal/proxy/askmode_test.go
@@ -1,0 +1,161 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAskServer_ServerMode(t *testing.T) {
+	dir := t.TempDir()
+
+	server, err := NewAskServer(dir)
+	if err != nil {
+		t.Fatalf("NewAskServer failed: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if server.Mode() != AskModeServer {
+		t.Errorf("expected server mode, got %s", server.Mode())
+	}
+
+	socketPath := AskSocketPath(dir)
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Fatalf("socket should exist: %v", err)
+	}
+}
+
+func TestAskServer_ClientMode(t *testing.T) {
+	dir := t.TempDir()
+	socketDir := AskSocketDir(dir)
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	socketPath := AskSocketPath(dir)
+
+	// Create a mock monitor server
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			connCh <- conn
+		}
+	}()
+
+	server, err := NewAskServer(dir)
+	if err != nil {
+		t.Fatalf("NewAskServer failed: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if server.Mode() != AskModeClient {
+		t.Errorf("expected client mode, got %s", server.Mode())
+	}
+
+	select {
+	case conn := <-connCh:
+		_ = conn.Close()
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitor server did not receive connection")
+	}
+}
+
+func TestAskServer_ClientMode_Ask(t *testing.T) {
+	dir := t.TempDir()
+	socketDir := AskSocketDir(dir)
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	socketPath := AskSocketPath(dir)
+
+	// Create a mock monitor that auto-approves
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		decoder := json.NewDecoder(conn)
+		encoder := json.NewEncoder(conn)
+
+		for {
+			var req AskRequest
+			if err := decoder.Decode(&req); err != nil {
+				return
+			}
+			_ = encoder.Encode(AskResponse{
+				ID:     req.ID,
+				Action: FilterActionAllow,
+			})
+		}
+	}()
+
+	server, err := NewAskServer(dir)
+	if err != nil {
+		t.Fatalf("NewAskServer failed: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	// Give client time to connect
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := server.Ask(ctx, &AskRequest{
+		ID:     "1",
+		Method: "GET",
+		URL:    "https://example.com",
+		Host:   "example.com",
+	})
+	if err != nil {
+		t.Fatalf("Ask failed: %v", err)
+	}
+	if resp.Action != FilterActionAllow {
+		t.Errorf("expected allow, got %s", resp.Action)
+	}
+}
+
+func TestAskServer_StaleSocket(t *testing.T) {
+	dir := t.TempDir()
+	socketDir := AskSocketDir(dir)
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	// Create a stale socket file (not listening)
+	socketPath := AskSocketPath(dir)
+	staleListener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	_ = staleListener.Close() // Close immediately, leaving stale file
+
+	server, err := NewAskServer(dir)
+	if err != nil {
+		t.Fatalf("NewAskServer failed: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if server.Mode() != AskModeServer {
+		t.Errorf("expected server mode after stale cleanup, got %s", server.Mode())
+	}
+}

--- a/internal/proxy/askmode_test.go
+++ b/internal/proxy/askmode_test.go
@@ -9,8 +9,20 @@ import (
 	"time"
 )
 
+// shortTempDir creates a short temp directory suitable for Unix socket paths.
+// macOS limits socket paths to 104 bytes; t.TempDir() paths are too long.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ds-")
+	if err != nil {
+		t.Fatalf("failed to create short temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestAskServer_ServerMode(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 
 	server, err := NewAskServer(dir)
 	if err != nil {
@@ -29,7 +41,7 @@ func TestAskServer_ServerMode(t *testing.T) {
 }
 
 func TestAskServer_ClientMode(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 	socketDir := AskSocketDir(dir)
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
@@ -71,7 +83,7 @@ func TestAskServer_ClientMode(t *testing.T) {
 }
 
 func TestAskServer_ClientMode_Ask(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 	socketDir := AskSocketDir(dir)
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
@@ -141,7 +153,7 @@ func TestAskServer_ClientMode_Ask(t *testing.T) {
 }
 
 func TestAskServer_StaleSocket(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 	socketDir := AskSocketDir(dir)
 	if err := os.MkdirAll(socketDir, 0o700); err != nil {
 		t.Fatalf("mkdir failed: %v", err)

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Enabled        bool
 	Port           int
 	BindAddress    string // IP to bind to (default "127.0.0.1"). For Docker, use DockerBridgeIP().
+	SandboxBase    string // Root directory for this sandbox instance
 	CADir          string
 	CACertPath     string
 	CAKeyPath      string
@@ -62,12 +63,28 @@ func NewConfig(sandboxBase string, port int) *Config {
 	return &Config{
 		Enabled:        true,
 		Port:           port,
+		SandboxBase:    sandboxBase,
 		CADir:          caDir,
 		CACertPath:     filepath.Join(caDir, CACertFile),
 		CAKeyPath:      filepath.Join(caDir, CAKeyFile),
 		LogDir:         filepath.Join(logBase, ProxyLogDirName),
 		InternalLogDir: filepath.Join(logBase, InternalLogDirName),
 	}
+}
+
+// AskSocketDir returns the directory for the ask mode socket.
+func AskSocketDir(sandboxBase string) string {
+	return filepath.Join(sandboxBase, LogBaseDirName, ProxyLogDirName, ".ask")
+}
+
+// AskSocketPath returns the full path to the ask mode Unix socket.
+func AskSocketPath(sandboxBase string) string {
+	return filepath.Join(AskSocketDir(sandboxBase), "ask.sock")
+}
+
+// AskLockPath returns the path to the ask mode lock file.
+func AskLockPath(sandboxBase string) string {
+	return filepath.Join(AskSocketDir(sandboxBase), "ask.lock")
 }
 
 func (c *Config) EnsureCADir() error {

--- a/internal/proxy/config_test.go
+++ b/internal/proxy/config_test.go
@@ -1,0 +1,27 @@
+package proxy
+
+import "testing"
+
+func TestAskSocketPath(t *testing.T) {
+	path := AskSocketPath("/tmp/sandbox-test")
+	expected := "/tmp/sandbox-test/logs/proxy/.ask/ask.sock"
+	if path != expected {
+		t.Errorf("AskSocketPath = %q, want %q", path, expected)
+	}
+}
+
+func TestAskSocketDir(t *testing.T) {
+	dir := AskSocketDir("/tmp/sandbox-test")
+	expected := "/tmp/sandbox-test/logs/proxy/.ask"
+	if dir != expected {
+		t.Errorf("AskSocketDir = %q, want %q", dir, expected)
+	}
+}
+
+func TestAskLockPath(t *testing.T) {
+	path := AskLockPath("/tmp/sandbox-test")
+	expected := "/tmp/sandbox-test/logs/proxy/.ask/ask.lock"
+	if path != expected {
+		t.Errorf("AskLockPath = %q, want %q", path, expected)
+	}
+}

--- a/internal/proxy/filelock.go
+++ b/internal/proxy/filelock.go
@@ -1,0 +1,106 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+// FileLock provides file-based mutual exclusion using flock.
+type FileLock struct {
+	path string
+	file *os.File
+}
+
+// AcquireFileLock acquires an exclusive lock, removing stale locks first.
+// Blocks until the lock is acquired.
+func AcquireFileLock(path string) (*FileLock, error) {
+	if err := removeStaleLock(path); err != nil {
+		return nil, err
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open lock file: %w", err)
+	}
+
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("failed to acquire lock: %w", err)
+	}
+
+	_ = file.Truncate(0)
+	_, _ = file.WriteString(strconv.Itoa(os.Getpid()))
+	_ = file.Sync()
+
+	return &FileLock{path: path, file: file}, nil
+}
+
+// TryFileLock attempts to acquire the lock without blocking.
+// Returns error if the lock is already held.
+func TryFileLock(path string) (*FileLock, error) {
+	if err := removeStaleLock(path); err != nil {
+		return nil, err
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open lock file: %w", err)
+	}
+
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock already held: %w", err)
+	}
+
+	_ = file.Truncate(0)
+	_, _ = file.WriteString(strconv.Itoa(os.Getpid()))
+	_ = file.Sync()
+
+	return &FileLock{path: path, file: file}, nil
+}
+
+// Release releases the lock and removes the lock file.
+func (l *FileLock) Release() error {
+	if l.file == nil {
+		return nil
+	}
+	_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	_ = l.file.Close()
+	l.file = nil
+	_ = os.Remove(l.path)
+	return nil
+}
+
+// removeStaleLock removes lock files left by dead processes.
+func removeStaleLock(path string) error {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		// Corrupt lock file, remove it
+		_ = os.Remove(path)
+		return nil
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(path)
+		return nil
+	}
+
+	err = proc.Signal(syscall.Signal(0))
+	if err != nil {
+		// Process is dead, remove stale lock
+		_ = os.Remove(path)
+	}
+
+	return nil
+}

--- a/internal/proxy/filelock.go
+++ b/internal/proxy/filelock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -83,13 +84,14 @@ func removeStaleLock(path string) error {
 		return err
 	}
 
-	pid, err := strconv.Atoi(string(data))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
 		// Corrupt lock file, remove it
 		_ = os.Remove(path)
 		return nil
 	}
 
+	// FindProcess never errors on Unix, but we handle it for portability.
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		_ = os.Remove(path)

--- a/internal/proxy/filelock_test.go
+++ b/internal/proxy/filelock_test.go
@@ -1,0 +1,61 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileLock_AcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	lock, err := AcquireFileLock(path)
+	if err != nil {
+		t.Fatalf("AcquireFileLock failed: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file should exist: %v", err)
+	}
+
+	if err := lock.Release(); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("lock file should be removed after release")
+	}
+}
+
+func TestFileLock_Contention(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	lock1, err := AcquireFileLock(path)
+	if err != nil {
+		t.Fatalf("first lock failed: %v", err)
+	}
+	defer func() { _ = lock1.Release() }()
+
+	_, err = TryFileLock(path)
+	if err == nil {
+		t.Fatal("second lock should fail")
+	}
+}
+
+func TestFileLock_StaleDetection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	// Create a lock file with a non-existent PID
+	if err := os.WriteFile(path, []byte("999999999"), 0o600); err != nil {
+		t.Fatalf("failed to create stale lock: %v", err)
+	}
+
+	lock, err := AcquireFileLock(path)
+	if err != nil {
+		t.Fatalf("should acquire stale lock: %v", err)
+	}
+	defer func() { _ = lock.Release() }()
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -100,7 +100,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	var askServer *AskServer
 	var askQueue *AskQueue
 	if cfg.Filter != nil && cfg.Filter.DefaultAction == FilterActionAsk {
-		askServer, err = NewAskServer(cfg.LogDir)
+		askServer, err = NewAskServer(cfg.SandboxBase)
 		if err != nil {
 			_ = proxyLogger.Close()
 			_ = reqLogger.Close()


### PR DESCRIPTION
## Summary

- `proxy monitor` can now create and own the ask socket when started **before** the sandbox, eliminating missed early requests
- AskServer auto-detects pre-existing monitor sockets and connects as a client instead of creating its own
- Monitor persists across sandbox restarts — no need to reconnect
- File lock prevents multiple monitors from competing for the same socket
- Backward compatible: sandbox-first startup order works unchanged

## Changes

- `internal/proxy/config.go` — `AskSocketPath`, `AskSocketDir`, `AskLockPath` helpers + `SandboxBase` field
- `internal/proxy/filelock.go` — File lock utility with stale PID detection
- `internal/proxy/askmode.go` — AskServer dual mode (server/client)
- `cmd/devsandbox/proxy.go` — Monitor server mode, auto-detection of startup order

## Test plan

- [x] `TestAskServer_ServerMode` — default server mode preserved
- [x] `TestAskServer_ClientMode` — detects pre-existing socket, connects as client
- [x] `TestAskServer_ClientMode_Ask` — end-to-end request/response in client mode
- [x] `TestAskServer_StaleSocket` — stale socket cleanup falls back to server mode
- [x] `TestFileLock_AcquireRelease` — lock acquire and release lifecycle
- [x] `TestFileLock_Contention` — second lock attempt fails
- [x] `TestFileLock_StaleDetection` — dead PID lock cleanup
- [x] `TestIntegration_MonitorFirst` — full flow: monitor first, sandbox connects, restart reconnects